### PR TITLE
Add gem version badge (Retina friendly)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# angularjs-rails
+# angularjs-rails <a href="http://badge.fury.io/rb/angularjs-rails"><img src="https://badge.fury.io/rb/angularjs-rails@2x.png" alt="Gem Version" height="18"></a>
 
 angularjs-rails wraps the [Angular.js](http://angularjs.org) library for use in Rails 3.1 and above. Assets will minify automatically during production.
 


### PR DESCRIPTION
This makes it easier for people to see what the latest version is and access the gem's Rubygems information.
