### PR TITLE
Added better support for usage outside of rails (i.e. Middleman)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+/.idea

--- a/lib/angularjs-rails.rb
+++ b/lib/angularjs-rails.rb
@@ -2,7 +2,10 @@ require "angularjs-rails/version"
 
 module AngularJS
   module Rails
-    class Engine < ::Rails::Engine
+    if defined? Rails::Engine
+      require "angularjs-rails/engine"
+    elsif defined? Sprockets
+      require "angularjs-rails/sprockets"
     end
   end
 end

--- a/lib/angularjs-rails/engine.rb
+++ b/lib/angularjs-rails/engine.rb
@@ -1,0 +1,6 @@
+module AngularJS
+  module Rails
+    class Engine < ::Rails::Engine
+    end
+  end
+end

--- a/lib/angularjs-rails/sprockets.rb
+++ b/lib/angularjs-rails/sprockets.rb
@@ -1,0 +1,3 @@
+require 'sprockets'
+
+Sprockets.append_path File.expand_path("../../../vendor/assets/javascript", __FILE__)


### PR DESCRIPTION
I'm testing for Rails and Sprockets support and only registering the Engine if Rails is available. If sprockets is there the javascripts path gets registered. This way they can be included in js files using `//= require 'angular.js'`
