### PR TITLE
Fix detection of Rails::Engine for Rails 4

### DIFF
--- a/lib/angularjs-rails.rb
+++ b/lib/angularjs-rails.rb
@@ -2,7 +2,7 @@ require "angularjs-rails/version"
 
 module AngularJS
   module Rails
-    if defined? Rails::Engine
+    if defined? ::Rails::Engine
       require "angularjs-rails/engine"
     elsif defined? Sprockets
       require "angularjs-rails/sprockets"


### PR DESCRIPTION
We tried to upgrade to angularjs-rails 1.2.12, but now get this error:

```
couldn't find file 'angular'
```

when trying to load the application.

Assumedly the culprit is this commit: 137f7cfffa9c5e9cd9dac9d9a3525d7738060612
We see that locally we get into the `elsif defined? Sprockets` condition, which is probably not what was intended for a Rails 4 project.

It works for us now if we use `defined? ::Rails::Engine`, but I'm not smart enough with engines to know exactly why or whether it will still work for Rails 3.
